### PR TITLE
feat: update to use bbs-signatures

### DIFF
--- a/__tests__/Bls12381G2KeyPair.spec.ts
+++ b/__tests__/Bls12381G2KeyPair.spec.ts
@@ -24,8 +24,8 @@ import {
 import { Bls12381G2KeyPair } from "../src";
 import {
   DEFAULT_BLS12381_PRIVATE_KEY_LENGTH,
-  DEFAULT_BLS12381_PUBLIC_KEY_LENGTH
-} from "@mattrglobal/node-bbs-signatures";
+  DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH
+} from "@mattrglobal/bbs-signatures";
 import base58 from "bs58";
 
 const key = new Bls12381G2KeyPair(exampleBls12381KeyPair);
@@ -47,7 +47,7 @@ describe("Bls12381G2KeyPair", () => {
       DEFAULT_BLS12381_PRIVATE_KEY_LENGTH
     );
     expect(myLdKey.publicKeyBuffer.length).toBe(
-      DEFAULT_BLS12381_PUBLIC_KEY_LENGTH
+      DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH
     );
 
     expect(myLdKey.publicKey).toEqual(exampleBls12381KeyPair.publicKeyBase58);
@@ -68,7 +68,7 @@ describe("Bls12381G2KeyPair", () => {
       DEFAULT_BLS12381_PRIVATE_KEY_LENGTH
     );
     expect(myLdKey.publicKeyBuffer.length).toBe(
-      DEFAULT_BLS12381_PUBLIC_KEY_LENGTH
+      DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH
     );
 
     expect(myLdKey.publicKey).toEqual(exampleBls12381KeyPair.publicKeyBase58);
@@ -89,7 +89,7 @@ describe("Bls12381G2KeyPair", () => {
     expect(myLdKey.publicKeyBuffer).toBeDefined();
 
     expect(myLdKey.publicKeyBuffer.length).toBe(
-      DEFAULT_BLS12381_PUBLIC_KEY_LENGTH
+      DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH
     );
 
     expect(myLdKey.publicKey).toEqual(exampleBls12381KeyPair.publicKeyBase58);
@@ -110,7 +110,7 @@ describe("Bls12381G2KeyPair", () => {
     expect(myLdKey.publicKeyBuffer).toBeDefined();
 
     expect(myLdKey.publicKeyBuffer.length).toBe(
-      DEFAULT_BLS12381_PUBLIC_KEY_LENGTH
+      DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH
     );
 
     expect(myLdKey.publicKey).toEqual(exampleBls12381KeyPair.publicKeyBase58);
@@ -137,7 +137,7 @@ describe("Bls12381G2KeyPair", () => {
     expect(myLdKey.publicKeyBuffer).toBeDefined();
 
     expect(myLdKey.publicKeyBuffer.length).toBe(
-      DEFAULT_BLS12381_PUBLIC_KEY_LENGTH
+      DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH
     );
 
     expect(myLdKey.publicKey).toEqual(exampleBls12381KeyPair.publicKeyBase58);
@@ -274,7 +274,7 @@ describe("Bls12381G2KeyPair", () => {
       DEFAULT_BLS12381_PRIVATE_KEY_LENGTH
     );
     expect(myLdKey.publicKeyBuffer.length).toBe(
-      DEFAULT_BLS12381_PUBLIC_KEY_LENGTH
+      DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH
     );
   });
 
@@ -300,15 +300,15 @@ describe("Bls12381G2KeyPair", () => {
       DEFAULT_BLS12381_PRIVATE_KEY_LENGTH
     );
     expect(myLdKey.publicKeyBuffer.length).toBe(
-      DEFAULT_BLS12381_PUBLIC_KEY_LENGTH
+      DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH
     );
 
     expect(myLdKey.privateKeyBuffer).toEqual(
-      base58.decode("7KbvkY9brt8gBBfyWSEYCuLj7FvjymepmszKubLhr3Xu")
+      base58.decode("6DLV2ijYvG7Dh45sP7V9GfprG7sB26GYaJnSuFQX6cD1")
     );
     expect(myLdKey.publicKeyBuffer).toEqual(
       base58.decode(
-        "mkQu8DwH1sQGgxoTT76zUHzrZxKqaHKdoLJymK3H6baf2vkpBfR4sMZLAN6QpegRyjbwGmmH69HEwH3oqXUjpGnDGY29AmexaryVZJe3WDcQm186WD8tVQhvBo8uuommeAg"
+        "22ChK6FX33MgZtQ9yzTMHTYin7X3yfwHstNvZQ4ScJsodX7H75h9t3VCZhE6EaSpAeUeWrfy9PPPcMzWKQ7zsxXG7tigKqoxGgtyeAjpaJSTcNSXAj2YKRwHYQ1dfLv6ZuHq"
       )
     );
   });

--- a/__tests__/__fixtures__/index.ts
+++ b/__tests__/__fixtures__/index.ts
@@ -13,11 +13,14 @@
 
 import exampleBls12381KeyPair from "./exampleBls12381KeyPair.json";
 
-const exampleSingleMessage = "someData";
+const exampleSingleMessage = new Uint8Array(Buffer.from("someData"));
 const exampleSingleMessageSignature =
   "o6eLL+eFfvSdh+vyNCsyZxmVJTLe2DuqD93W6hG7M7se+9MdoyEdPRNiB6aM5XjVBaJQ6wSt41HTVcHTnq3aOCDAVlc27m70SJwVCUgbsqA9J/tBEqfZF7VEGs79765wIubvyed/WQR/wZGUlRSg/w==";
 
-const exampleMultiMessage = ["test", "value"];
+const exampleMultiMessage = [
+  new Uint8Array(Buffer.from("test")),
+  new Uint8Array(Buffer.from("value"))
+];
 const exampleMultiMessageSignature =
   "gTeYNYnogNM2En/YLq7pEtDDOi1PIlVtKBevXQjIMZtk1KdOtApAw2HUNV0eFG5mXhD28X0tmXbubLqwQb0K/lKxVZJvTS2MyuP1bRDnsyJB9tOE/AnpoNDWKnjjVu6tQNgG3YNQsJZhVgvHyUAo8A==";
 

--- a/package.json
+++ b/package.json
@@ -41,9 +41,6 @@
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md",
     "version:release": "yarn version --minor --message \"chore(release): publish [skip ci]\""
   },
-  "optionalDependencies": {
-    "@mattrglobal/node-bbs-signatures": "0.9.0"
-  },
   "devDependencies": {
     "@commitlint/cli": "8.3.5",
     "@commitlint/config-conventional": "8.3.4",
@@ -68,7 +65,7 @@
     "typescript": "3.7.5"
   },
   "dependencies": {
-    "@mattrglobal/bbs-signatures": "0.3.0",
+    "@mattrglobal/bbs-signatures": "0.3.1-unstable.92238cf",
     "bs58": "4.0.1"
   },
   "husky": {

--- a/src/Bls12381G2KeyPair.ts
+++ b/src/Bls12381G2KeyPair.ts
@@ -14,8 +14,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import bs58 from "bs58";
 import {
-  DEFAULT_BLS12381_PUBLIC_KEY_LENGTH,
-  generateBls12381KeyPair,
+  DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH,
+  generateBls12381G2KeyPair,
   blsVerify,
   blsSign
 } from "@mattrglobal/bbs-signatures";
@@ -66,8 +66,8 @@ const signerFactory = (key: Bls12381G2KeyPair): KeyPairSigner => {
   }
   return {
     async sign({ data }): Promise<string> {
-      //TODO assert data runtime string | string[]
-      if (typeof data === "string") {
+      //TODO assert data runtime Uint8Array | Uint8Array[]
+      if (data instanceof Uint8Array) {
         return Buffer.from(
           blsSign({
             messages: [data],
@@ -112,8 +112,8 @@ const verifierFactory = (key: Bls12381G2KeyPair): KeyPairVerifier => {
 
   return {
     async verify({ data, signature }): Promise<boolean> {
-      //TODO assert data
-      if (typeof data === "string") {
+      //TODO assert data instance of Uint8Array | Uint8Array[]
+      if (data instanceof Uint8Array) {
         return blsVerify({
           messages: [data],
           publicKey: new Uint8Array(key.publicKeyBuffer),
@@ -178,8 +178,8 @@ export class Bls12381G2KeyPair {
     options?: GenerateKeyPairOptions
   ): Promise<Bls12381G2KeyPair> {
     const keyPair = options?.seed
-      ? generateBls12381KeyPair(options.seed)
-      : generateBls12381KeyPair();
+      ? generateBls12381G2KeyPair(options.seed)
+      : generateBls12381G2KeyPair();
     return new Bls12381G2KeyPair({
       ...options,
       privateKeyBase58: bs58.encode(keyPair.secretKey as Uint8Array),
@@ -223,9 +223,9 @@ export class Bls12381G2KeyPair {
     // parse of the multi-format public key removing the `z` that indicates base58 encoding
     const buffer = bs58.decode(fingerprint.substr(1));
 
-    if (buffer.length !== DEFAULT_BLS12381_PUBLIC_KEY_LENGTH + 2) {
+    if (buffer.length !== DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH + 2) {
       throw new Error(
-        `Unsupported public key length: expected \`${DEFAULT_BLS12381_PUBLIC_KEY_LENGTH}\` received \`${buffer.length -
+        `Unsupported public key length: expected \`${DEFAULT_BLS12381_G2_PUBLIC_KEY_LENGTH}\` received \`${buffer.length -
           2}\``
       );
     }

--- a/src/types/KeyPairSigner.ts
+++ b/src/types/KeyPairSigner.ts
@@ -25,5 +25,5 @@ export interface KeyPairSigner {
  * Key pair signer options
  */
 export interface KeyPairSignerOptions {
-  readonly data: string | string[];
+  readonly data: Uint8Array | Uint8Array[];
 }

--- a/src/types/KeyPairVerifier.ts
+++ b/src/types/KeyPairVerifier.ts
@@ -25,6 +25,6 @@ export interface KeyPairVerifier {
  * Key pair verifier options
  */
 export interface KeyPairVerifierOptions {
-  readonly data: string | string[];
+  readonly data: Uint8Array | Uint8Array[];
   readonly signature: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -594,17 +594,17 @@
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
-"@mattrglobal/bbs-signatures@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@mattrglobal/bbs-signatures/-/bbs-signatures-0.3.0.tgz#3f39c5a5b495cf8e004efa8222f3377ec58eb337"
-  integrity sha512-ymTzzVNLRD1NZl6G0Yrkh2dr+17EPzDbdP4qiVyvrS3r4vAJnbXPB3gLYm74SMBmYXsMpZCb5nPWzkMtdeApLQ==
+"@mattrglobal/bbs-signatures@0.3.1-unstable.92238cf":
+  version "0.3.1-unstable.92238cf"
+  resolved "https://registry.yarnpkg.com/@mattrglobal/bbs-signatures/-/bbs-signatures-0.3.1-unstable.92238cf.tgz#ca9251af45211585a1ab1069c80e4893ed96d848"
+  integrity sha512-9embdzQ39+W41c2a+ocEwAQjN9pnYMIYWq70F6vQqhMforgqLDJyFdyTyuvqyvnpG8WXH4SnbzLRlu1MYghVOQ==
   optionalDependencies:
-    "@mattrglobal/node-bbs-signatures" "0.9.0"
+    "@mattrglobal/node-bbs-signatures" "0.9.1-unstable.4cb57b7"
 
-"@mattrglobal/node-bbs-signatures@0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.9.0.tgz#e581988babfa06ab50f2ba4e068877420e84bf11"
-  integrity sha512-FGy5kucFie3g6sTGFTjp6e91VicDncRFIbpvgIqGDyySJZtgPCL1es6yhEPrWfTnbX3zcXQfdm1OWhFlBLWP9w==
+"@mattrglobal/node-bbs-signatures@0.9.1-unstable.4cb57b7":
+  version "0.9.1-unstable.4cb57b7"
+  resolved "https://registry.yarnpkg.com/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.9.1-unstable.4cb57b7.tgz#b210dc4871de7fa813b7b9755dc7bde9ef29091f"
+  integrity sha512-9EpQ0u0hXeD5RcYxs7kgHXBZAsKeWBQFLSR5B7OLvO46OnuLXfcjKwDG04JypJuMm6bjFz2Z/4qUeZpysAgR6w==
   dependencies:
     neon-cli "0.4.0"
     node-pre-gyp "0.14.0"


### PR DESCRIPTION
## Description

Updates this libraries core dependency to be on [bbs-signatures](https://github.com/mattrglobal/bbs-signatures/) which is WASM based meaning this library is now browser compatible. Note bbs-signatures has an optional dependency on node-bbs-signatures so that consumers of this library running in node environments can take advantage of the node module for the best performance.

The changes include
- The top level API for signing and verifying BBS signatures is now based on Uint8Arrays instead of strings. 
- `generateBls12381KeyPair` has been renamed to `generateBls12381G2KeyPair` to make way for supporting G1 BLS keys.

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

Supporting more of the TS and JS environment

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Sign and verify functions now expect the data as Uint8Array's instead of strings

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
