### PR TITLE
feat: update sign and verify apis to use uint8arrays

### DIFF
--- a/__tests__/Bls12381G2KeyPair.spec.ts
+++ b/__tests__/Bls12381G2KeyPair.spec.ts
@@ -341,7 +341,9 @@ describe("Bls12381G2KeyPair", () => {
     expect(
       await verify({
         data: exampleSingleMessage,
-        signature: exampleSingleMessageSignature
+        signature: new Uint8Array(
+          Buffer.from(exampleSingleMessageSignature, "base64")
+        )
       })
     ).toBe(true);
   });
@@ -351,7 +353,9 @@ describe("Bls12381G2KeyPair", () => {
     expect(
       await verify({
         data: exampleMultiMessage,
-        signature: exampleMultiMessageSignature
+        signature: new Uint8Array(
+          Buffer.from(exampleMultiMessageSignature, "base64")
+        )
       })
     ).toBe(true);
   });
@@ -359,7 +363,10 @@ describe("Bls12381G2KeyPair", () => {
   it("should not verify bad signature of correct length", async () => {
     expect(typeof verify).toBe("function");
     expect(
-      await verify({ data: exampleSingleMessage, signature: badSignature })
+      await verify({
+        data: exampleSingleMessage,
+        signature: new Uint8Array(Buffer.from(badSignature, "base64"))
+      })
     ).toBe(false);
   });
 
@@ -368,7 +375,7 @@ describe("Bls12381G2KeyPair", () => {
     expect(
       await verify({
         data: exampleSingleMessage,
-        signature: badSignatureBadLength
+        signature: new Uint8Array(Buffer.from(badSignatureBadLength, "base64"))
       })
     ).toBe(false);
   });

--- a/src/Bls12381G2KeyPair.ts
+++ b/src/Bls12381G2KeyPair.ts
@@ -59,34 +59,30 @@ const BLS12381G2_MULTICODEC_IDENTIFIER = 0xeb;
 const signerFactory = (key: Bls12381G2KeyPair): KeyPairSigner => {
   if (!key.privateKeyBuffer) {
     return {
-      async sign(): Promise<string> {
+      async sign(): Promise<Uint8Array> {
         throw new Error("No private key to sign with.");
       }
     };
   }
   return {
-    async sign({ data }): Promise<string> {
+    async sign({ data }): Promise<Uint8Array> {
       //TODO assert data runtime Uint8Array | Uint8Array[]
       if (data instanceof Uint8Array) {
-        return Buffer.from(
-          blsSign({
-            messages: [data],
-            keyPair: {
-              secretKey: new Uint8Array(key.privateKeyBuffer as Uint8Array),
-              publicKey: new Uint8Array(key.publicKeyBuffer)
-            }
-          })
-        ).toString("base64");
-      }
-      return Buffer.from(
-        blsSign({
-          messages: data,
+        return blsSign({
+          messages: [data],
           keyPair: {
             secretKey: new Uint8Array(key.privateKeyBuffer as Uint8Array),
             publicKey: new Uint8Array(key.publicKeyBuffer)
           }
-        })
-      ).toString("base64");
+        });
+      }
+      return blsSign({
+        messages: data,
+        keyPair: {
+          secretKey: new Uint8Array(key.privateKeyBuffer as Uint8Array),
+          publicKey: new Uint8Array(key.publicKeyBuffer)
+        }
+      });
     }
   };
 };
@@ -117,13 +113,13 @@ const verifierFactory = (key: Bls12381G2KeyPair): KeyPairVerifier => {
         return blsVerify({
           messages: [data],
           publicKey: new Uint8Array(key.publicKeyBuffer),
-          signature: new Uint8Array(Buffer.from(signature, "base64"))
+          signature
         }).verified;
       }
       return blsVerify({
         messages: data,
         publicKey: new Uint8Array(key.publicKeyBuffer),
-        signature: new Uint8Array(Buffer.from(signature, "base64"))
+        signature
       }).verified;
     }
   };

--- a/src/types/KeyPairSigner.ts
+++ b/src/types/KeyPairSigner.ts
@@ -18,7 +18,7 @@ export interface KeyPairSigner {
   /**
    * Signer function
    */
-  readonly sign: (options: KeyPairSignerOptions) => Promise<string>;
+  readonly sign: (options: KeyPairSignerOptions) => Promise<Uint8Array>;
 }
 
 /**

--- a/src/types/KeyPairVerifier.ts
+++ b/src/types/KeyPairVerifier.ts
@@ -26,5 +26,5 @@ export interface KeyPairVerifier {
  */
 export interface KeyPairVerifierOptions {
   readonly data: Uint8Array | Uint8Array[];
-  readonly signature: string;
+  readonly signature: Uint8Array;
 }


### PR DESCRIPTION
## Description

Update sign and verify apis to use Uint8Arrays

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

Updating the API to deal in buffer rather than strings, common pattern in crypto libraries

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

As above

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
