### PR TITLE
feat: add async api support for bbs-signatures

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript": "3.7.5"
   },
   "dependencies": {
-    "@mattrglobal/bbs-signatures": "0.4.0",
+    "@mattrglobal/bbs-signatures": "0.4.1-unstable.10c5b9b",
     "rfc4648": "1.4.0",
     "bs58": "4.0.1"
   },

--- a/src/Bls12381G1KeyPair.ts
+++ b/src/Bls12381G1KeyPair.ts
@@ -174,8 +174,8 @@ export class Bls12381G1KeyPair {
   ): Promise<Bls12381G1KeyPair> {
     // TODO: Do we want to set a minimum size input for the seed?
     const keyPair = options?.seed
-      ? generateBls12381G1KeyPair(options.seed)
-      : generateBls12381G1KeyPair();
+      ? await generateBls12381G1KeyPair(options.seed)
+      : await generateBls12381G1KeyPair();
     return new Bls12381G1KeyPair({
       ...options,
       privateKeyBase58: bs58.encode(keyPair.secretKey as Uint8Array),

--- a/src/Bls12381G2KeyPair.ts
+++ b/src/Bls12381G2KeyPair.ts
@@ -77,7 +77,7 @@ const signerFactory = (key: Bls12381G2KeyPair): KeyPairSigner => {
     async sign({ data }): Promise<Uint8Array> {
       //TODO assert data runtime Uint8Array | Uint8Array[]
       if (data instanceof Uint8Array) {
-        return blsSign({
+        return await blsSign({
           messages: [data],
           keyPair: {
             secretKey: new Uint8Array(key.privateKeyBuffer as Uint8Array),
@@ -85,7 +85,7 @@ const signerFactory = (key: Bls12381G2KeyPair): KeyPairSigner => {
           }
         });
       }
-      return blsSign({
+      return await blsSign({
         messages: data,
         keyPair: {
           secretKey: new Uint8Array(key.privateKeyBuffer as Uint8Array),
@@ -119,17 +119,21 @@ const verifierFactory = (key: Bls12381G2KeyPair): KeyPairVerifier => {
     async verify({ data, signature }): Promise<boolean> {
       //TODO assert data instance of Uint8Array | Uint8Array[]
       if (data instanceof Uint8Array) {
-        return blsVerify({
-          messages: [data],
+        return (
+          await blsVerify({
+            messages: [data],
+            publicKey: new Uint8Array(key.publicKeyBuffer),
+            signature
+          })
+        ).verified;
+      }
+      return (
+        await blsVerify({
+          messages: data,
           publicKey: new Uint8Array(key.publicKeyBuffer),
           signature
-        }).verified;
-      }
-      return blsVerify({
-        messages: data,
-        publicKey: new Uint8Array(key.publicKeyBuffer),
-        signature
-      }).verified;
+        })
+      ).verified;
     }
   };
 };
@@ -212,8 +216,8 @@ export class Bls12381G2KeyPair {
     options?: GenerateKeyPairOptions
   ): Promise<Bls12381G2KeyPair> {
     const keyPair = options?.seed
-      ? generateBls12381G2KeyPair(options.seed)
-      : generateBls12381G2KeyPair();
+      ? await generateBls12381G2KeyPair(options.seed)
+      : await generateBls12381G2KeyPair();
     return new Bls12381G2KeyPair({
       ...options,
       privateKeyBase58: bs58.encode(keyPair.secretKey as Uint8Array),

--- a/yarn.lock
+++ b/yarn.lock
@@ -594,17 +594,17 @@
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
-"@mattrglobal/bbs-signatures@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@mattrglobal/bbs-signatures/-/bbs-signatures-0.4.0.tgz#de106c4a5946e590dc1ecaf672e90c284a5fba85"
-  integrity sha512-r6ed3N9xO+7AlO6FF2rVksH+HjfLwxZ9eKWHg3saTi5hzhJyehE3Qahj+goddgYD6emzwzrVbawNZDTttMQUKg==
+"@mattrglobal/bbs-signatures@0.4.1-unstable.10c5b9b":
+  version "0.4.1-unstable.10c5b9b"
+  resolved "https://registry.yarnpkg.com/@mattrglobal/bbs-signatures/-/bbs-signatures-0.4.1-unstable.10c5b9b.tgz#464fb47df1564c932cf4f4a0215054e57c24176d"
+  integrity sha512-xiUmIlQc/jjfaMNIcEC4M293/+7TonzN/vF0SfyzXloREhAXFz/ZKXosvqXZcwLh3qktl7xejUazCnS3tPjpRQ==
   optionalDependencies:
-    "@mattrglobal/node-bbs-signatures" "0.10.0"
+    "@mattrglobal/node-bbs-signatures" "0.11.0"
 
-"@mattrglobal/node-bbs-signatures@0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.10.0.tgz#6bdcdf135f8b101bf74f07207589104ef505db3d"
-  integrity sha512-i2sd61gXQJ0YJZ6JLUnKoQ8w+V39OOh5cdrYv0odnnF00H0a8y9JbSoDbzqEywFGol6oXk2ezFGI/ilU+1R7wQ==
+"@mattrglobal/node-bbs-signatures@0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.11.0.tgz#c63ab8648a529cfe1dd855cc78a93f78ee27a9f4"
+  integrity sha512-V0wcY0ZewrPOiMOrL3wam0oYL1SLbF2ihgAM6JQvLrAKw1MckYiJ8T4vL+nOBs2hf1PA1TZI+USe5mqMWuVKTw==
   dependencies:
     neon-cli "0.4.0"
     node-pre-gyp "0.14.0"


### PR DESCRIPTION
Updates this library to use the latest unstable release of bbs-signatures which features support for a new async based API for crypto operations.

Merging in with a dependency on the unstable version for now to test upstream, will be updated to the latest stable version of bbs-signatures prior to a new release of this library.

## Description

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
