### PR TITLE
chore: add mattrassurance synchronisation github workflow

### DIFF
--- a/.github/workflows/github_clone_assurance.yaml
+++ b/.github/workflows/github_clone_assurance.yaml
@@ -1,0 +1,23 @@
+name: Mirror repository to mattrassurance org
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  MirrorRepoToMATTRAssurance:
+    runs-on: [self-hosted, generic]
+    permissions:
+      contents: read
+    steps:
+      - name: mirror repo
+        uses: mattrinternal/sre-reusable-action/actions/github-clone-assurance@master
+        with:
+          github_repository: ${{ env.GITHUB_REPOSITORY }}
+          github_ref_name: ${{ env.GITHUB_REF_NAME }}
+          remote_git_user_name: ${{ secrets.MATTRASSURANCE_GIT_USER_NAME }}
+          remote_git_user_email: ${{ secrets.MATTRASSURANCE_GIT_USER_EMAIL }}
+          remote_git_user_pat: ${{ secrets.MATTRASSURANCE_GIT_USER_PAT }}
+          remote_git_repo: 'mattrassurance/bls12381-key-pair'


### PR DESCRIPTION
Adding a workflow to sync code of the repo to mattrassurance GitHub organisation when main branch is updated.

## Description

Adding a workflow to sync code of the repo to mattrassurance GitHub organisation when main branch is updated.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../blob/master/docs/CONTRIBUTING.md)** document.

## Motivation and Context

Adding a workflow to sync code of the repo to mattrassurance GitHub organisation when main branch is updated. 

Code will be scanned for security vulnerabilities by Snyk after synchronisation 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
