### PR TITLE
build(deps): bump @mattrglobal/bbs-signatures from 1.3.1 to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "typescript": "4.9.5"
   },
   "dependencies": {
-    "@mattrglobal/bbs-signatures": "1.3.1",
+    "@mattrglobal/bbs-signatures": "1.4.0",
     "bs58": "4.0.1",
     "rfc4648": "1.5.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -796,10 +796,10 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
-"@mattrglobal/bbs-signatures@1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@mattrglobal/bbs-signatures/-/bbs-signatures-1.3.1.tgz#ed00b9c5bb5ea7fb4ca1dc6316a32d0618acc82e"
-  integrity sha512-syZGkapPpktD2el4lPTCQRw/LSia6/NwBS83hzCKu4dTlaJRO636qo5NCiiQb+iBYWyZQQEzN0jdRik8N9EUGA==
+"@mattrglobal/bbs-signatures@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@mattrglobal/bbs-signatures/-/bbs-signatures-1.4.0.tgz#1ee59b81303e2e04925008a1a1dc1a375392aaa0"
+  integrity sha512-uBK1IWw48fqloO9W/yoDncTs9rfwfbG/53cOrrCQL7XkyZe4DtB40HcLbi3i+yxTYs5wytf1Qr4Z5RpzpW10jw==
   dependencies:
     "@stablelib/random" "1.0.0"
   optionalDependencies:
@@ -4664,9 +4664,9 @@ typical@^5.2.0:
   integrity sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==
 
 uglify-js@^3.1.4:
-  version "3.13.7"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.13.7.tgz#25468a3b39b1c875df03f0937b2b7036a93f3fee"
-  integrity sha512-1Psi2MmnZJbnEsgJJIlfnd7tFlJfitusmR7zDI8lXlFI0ACD4/Rm/xdrU8bh6zF0i74aiVoBtkRiFulkrmh3AA==
+  version "3.16.1"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.16.1.tgz#0e7ec928b3d0b1e1d952bce634c384fd56377317"
+  integrity sha512-X5BGTIDH8U6IQ1TIRP62YC36k+ULAa1d59BxlWvPUJ1NkW5L3FwcGfEzuVvGmhJFBu0YJ5Ge25tmRISqCmLiRQ==
 
 universalify@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description

Bumps internal dependency of @mattrglobal/bbs-signatures from 1.3.1 to 1.4.0 to fix uglify-js vulnerability

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../blob/master/docs/CONTRIBUTING.md)** document.

## Motivation and Context

Fixing security vulnerability

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
