### PR TITLE
docs: add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 [![MATTR](./docs/assets/mattr-logo-square.svg)](https://github.com/mattrglobal)
 
+## Deprecation Notice
+
+This library has been deprecated in favor of the [Pairing Cryptography](https://github.com/mattrglobal/pairing_crypto)
+library which implements the more modern
+[BBS Signature Scheme](https://www.ietf.org/archive/id/draft-irtf-cfrg-bbs-signatures-03.html).
+
 # bls12381-key-pair
 
 ![npm-version](https://badgen.net/npm/v/@mattrglobal/bls12381-key-pair)


### PR DESCRIPTION
## Description

This repository has served its purpose and will no longer be maintained. This adds a deprecation notice in README.

- [ ] ~Tests for the changes have been added (for bug fixes / features)~
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../blob/master/docs/CONTRIBUTING.md)** document.

## Motivation and Context

MATTR's latest implementation of the BBS draft spec can be found in our [pairing-crypto](https://github.com/mattrglobal/pairing_crypto) project.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

But the project will be archived, and will not receive further updates.

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
